### PR TITLE
Updates only selected text

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -17,19 +17,58 @@ CKEDITOR.plugins.add('texttransform',
             // set num for switcher loop
             var num = 0;
 
+            //applies a transformation function to the editor's selected text
+            var transformSelectedText = function (editor, transformFunc) {
+
+                var selection = editor.getSelection();
+                if (selection.getSelectedText().length > 0) {
+
+                    var range = selection.getRanges()[0],
+                        walker = new CKEDITOR.dom.walker(range),
+                        node,
+                        nodeText;
+
+                    //Transform only the selected sections of the first and last nodes,
+                    //but all of the intermediate nodes
+                    while ((node = walker.next())) {
+
+                        if (node.type == CKEDITOR.NODE_TEXT && node.getText()) {
+
+                            nodeText = node.$.textContent;
+
+                            if (node.equals(range.startContainer)) {
+
+                                nodeText = nodeText.substr(0, range.startOffset) +
+                                    transformFunc(nodeText.substr(range.startOffset));
+                            }
+                            else if (node.equals(range.endContainer)) {
+
+                                nodeText = transformFunc(nodeText.substr(0, range.endOffset)) +
+                                    nodeText.substr(range.endOffset);
+                            }
+                            else {
+
+                                nodeText = transformFunc(nodeText);
+                            }
+
+                            node.$.textContent = nodeText;
+                        }
+                    }
+                }
+            }
+
             // add transformTextSwitch command to be used with button
             editor.addCommand('transformTextSwitch',
                 {
-                    exec : function()
-                    {
+                    exec: function () {
                         var selection = editor.getSelection();
                         var commandArray = ['transformTextToUppercase', 'transformTextToLowercase', 'transformTextCapitalize'];
 
                         if (selection.getSelectedText().length > 0) {
-
+                            
                             selection.lock();
 
-                            editor.execCommand( commandArray[num] );
+                            editor.execCommand(commandArray[num]);
 
                             selection.unlock(true);
 
@@ -46,73 +85,51 @@ CKEDITOR.plugins.add('texttransform',
             // add transformTextToUppercase command to be used with buttons and 'execCommand' method
             editor.addCommand('transformTextToUppercase',
                 {
-                    exec : function()
-                    {
-                        var selection = editor.getSelection();
-                        if (selection.getSelectedText().length > 0) {
-				var ranges = selection.getRanges(),
-				    walker = new CKEDITOR.dom.walker( ranges[0] ), 
-				    node;
-				while ( ( node = walker.next() ) ) 
-					if ( node.type == CKEDITOR.NODE_TEXT && node.getText() ) 
-						if (editor.langCode == "tr") {
-							node.$.textContent = node.$.textContent.trToUpperCase();
-						} else {
-							node.$.textContent = node.$.textContent.toLocaleUpperCase();		
-						}
-                        }//if
-                    } //func
+                    exec: function () {
+                        transformSelectedText(editor, function (text) {
+
+                            if (editor.langCode == "tr") {
+                                return text.trToUpperCase();
+                            } else {
+                                return text.toLocaleUpperCase();
+                            }
+                        });                        
+                    } 
                 });
 
             // add transformTextToUppercase command to be used with buttons and 'execCommand' method
             editor.addCommand('transformTextToLowercase',
                 {
-                    exec : function()
-                    {
-                        var selection = editor.getSelection();
-                        if (selection.getSelectedText().length > 0) {
-				var ranges = selection.getRanges(),
-				    walker = new CKEDITOR.dom.walker( ranges[0] ), 
-				    node;
-				while ( ( node = walker.next() ) ) 
-					if ( node.type == CKEDITOR.NODE_TEXT && node.getText() ) 
-						if (editor.langCode == "tr") {
-							node.$.textContent = node.$.textContent.trToLowerCase();
-						} else {
-							node.$.textContent = node.$.textContent.toLocaleLowerCase();		
-						}
-						
-                        }//if
+                    exec: function () {                        
+                        transformSelectedText(editor, function (text) {
 
+                            if (editor.langCode == "tr") {
+                                return text.trToLowerCase();
+                            } else {
+                                return text.toLocaleLowerCase();
+                            }
+                        });
                     }
                 });
 
             // add transformTextCapitalize command to be used with buttons and 'execCommand' method
-            editor.addCommand( 'transformTextCapitalize',
+            editor.addCommand('transformTextCapitalize',
                 {
-                    exec : function()
-                    {
-                        var selection = editor.getSelection();
-                        if (selection.getSelectedText().length > 0) {
-				var ranges = selection.getRanges(),
-				    walker = new CKEDITOR.dom.walker( ranges[0] ), 
-				    node;
-				while ( ( node = walker.next() ) ) 
-					if ( node.type == CKEDITOR.NODE_TEXT && node.getText() )
-						node.$.textContent = node.$.textContent.replace(
-							/[^\s]\S*/g, 
-							function(txt){
-								if (editor.langCode == "tr") {
-									return  txt.charAt(0).trToUpperCase() + 
-										txt.substr(1).trToLowerCase();
-								} else {
-									return  txt.charAt(0).toLocaleUpperCase() + 
-										txt.substr(1).toLocaleLowerCase();
-								}
-							
-							}
-						);
-                        }//if
+                    exec: function () {
+                        transformSelectedText(editor, function (text) {
+
+                            return text.replace(/[^\s]\S*/g, 
+                                function (word) {
+                                    if (editor.langCode == "tr") {
+                                        return word.charAt(0).trToUpperCase() +
+                                            word.substr(1).trToLowerCase();
+                                    } else {
+                                        return word.charAt(0).toLocaleUpperCase() +
+                                            word.substr(1).toLocaleLowerCase();
+                                    }
+                                }
+                            );    
+                        });                                    
                     }
                 });
 


### PR DESCRIPTION
Separated the walker function into a separate function that only transforms the selected text of the first and last text nodes. Previously it would transform all the text of the first and last nodes, whether that text was selected or not.

Should solve issue #5, although the problem isn't limited to the inline editor and this solution retains styles and formatting, unlike the suggested code there.
